### PR TITLE
feat: add option to identify proxies from lib & prevent re-freezing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Usage
 
 - **target**: can be either an `object` or constructor `function`
 - **options**
-   - **addProxyIdentifier**: `boolean`, adds a symbol getter that detects Proxies created via this method
+   - **addProxyIdentifier**: `boolean`, adds a symbol getter that detects Proxies created via this method. Defaults to `false`.
+   - **preventRefreeze**: `boolean`, uses symbol added via `addProxyIdentifier` to identify frozen Proxies and doesn't re-freeze them. Defaults to `false`.
 
 ```js
 let obj = {

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Install
 Usage
 -----
 
-### proxyFreeze(target)
+### proxyFreeze(target, options)
 
 - **target**: can be either an `object` or constructor `function`
+- **options**
+   - **addProxyIdentifier**: `boolean`, adds a symbol getter that detects Proxies created via this method
 
 ```js
 let obj = {

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Usage
    - **preventRefreeze**: `boolean`, uses symbol added via `addProxyIdentifier` to identify frozen Proxies and doesn't re-freeze them. Defaults to `false`.
 
 ```js
-let obj = {
+const obj = {
   name: 'jp'
 }
 
-let obj2 = proxyFreeze(obj)
+const obj2 = proxyFreeze(obj)
 obj2.name = 'bob'
 
 process.once('warning', (warning) => {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function proxyFreeze (target, { addProxyIdentifier = false, preventRefreeze = fa
     throw new Error('cannot use preventRefreeze without addProxyIdentifier.')
   }
 
-  if (preventRefreeze && target?.[proxyIdentifier]) return target
+  if (preventRefreeze && target && target[proxyIdentifier]) return target
   if (addProxyIdentifier) return new Proxy(target, identifiableProxyHandler)
   return new Proxy(target, proxyHandler)
 }

--- a/index.js
+++ b/index.js
@@ -38,7 +38,17 @@ function proxyFreeze (target, { addProxyIdentifier = false, preventRefreeze = fa
     throw new Error('cannot use preventRefreeze without addProxyIdentifier.')
   }
 
-  if (preventRefreeze && target && target[proxyIdentifier]) return target
+  if (target && target[proxyIdentifier]) {
+    if (preventRefreeze) return target
+
+    const msg = 'Trying to freeze an already frozen object.'
+    if (typeof process === 'undefined') {
+      (console.warn.bind(console) || console.error.bind(console) || console.log.bind(console))(msg)
+    } else {
+      process.emitWarning(msg, 'ProxyFreezeWarning')
+    }
+  }
+
   if (addProxyIdentifier) return new Proxy(target, identifiableProxyHandler)
   return new Proxy(target, proxyHandler)
 }

--- a/index.js
+++ b/index.js
@@ -1,18 +1,21 @@
 const proxyIdentifier = Symbol('proxy-freeze-identifier')
 
+const warn = (msg) => {
+  // browser?
+  if (typeof process === 'undefined') {
+    (console.warn.bind(console) || console.error.bind(console) || console.log.bind(console))(msg)
+  } else {
+    process.emitWarning(msg, 'ProxyFreezeWarning')
+  }
+}
+
 const proxyHandler = {
   construct: (Target, args) => {
     return new Proxy(new Target(...args), proxyHandler)
   },
 
   set: (target, prop, val) => {
-    const msg = `Trying to set value of property (${prop}) of frozen object.`
-    // browser?
-    if (typeof process === 'undefined') {
-      (console.warn.bind(console) || console.error.bind(console) || console.log.bind(console))(msg)
-    } else {
-      process.emitWarning(msg, 'ProxyFreezeWarning')
-    }
+    warn(`Trying to set value of property (${prop}) of frozen object.`)
   }
 }
 
@@ -41,12 +44,7 @@ function proxyFreeze (target, { addProxyIdentifier = false, preventRefreeze = fa
   if (target && target[proxyIdentifier]) {
     if (preventRefreeze) return target
 
-    const msg = 'Trying to freeze an already frozen object.'
-    if (typeof process === 'undefined') {
-      (console.warn.bind(console) || console.error.bind(console) || console.log.bind(console))(msg)
-    } else {
-      process.emitWarning(msg, 'ProxyFreezeWarning')
-    }
+    warn('Trying to freeze an already frozen object.')
   }
 
   if (addProxyIdentifier) return new Proxy(target, identifiableProxyHandler)

--- a/index.js
+++ b/index.js
@@ -24,14 +24,21 @@ const identifiableProxyHandler = {
   }
 }
 
-function proxyFreeze (target, { addProxyIdentifier = false } = {}) {
+function proxyFreeze (target, { addProxyIdentifier = false, preventRefreeze = false } = {}) {
   if (typeof target !== 'function' && typeof target !== 'object') {
     throw new Error('proxyFreeze only supports constructor functions or objects.')
   }
   if (typeof addProxyIdentifier !== 'boolean') {
     throw new TypeError('addProxyIdentifier needs to be a boolean.')
   }
+  if (typeof preventRefreeze !== 'boolean') {
+    throw new TypeError('preventRefreeze needs to be a boolean.')
+  }
+  if (preventRefreeze && !addProxyIdentifier) {
+    throw new Error('cannot use preventRefreeze without addProxyIdentifier.')
+  }
 
+  if (preventRefreeze && target?.[proxyIdentifier]) return target
   if (addProxyIdentifier) return new Proxy(target, identifiableProxyHandler)
   return new Proxy(target, proxyHandler)
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const proxyIdentifier = Symbol('proxy-freeze-identifier')
 
 const proxyHandler = {
   construct: (Target, args) => {
@@ -15,12 +16,25 @@ const proxyHandler = {
   }
 }
 
-function proxyFreeze (target) {
+const identifiableProxyHandler = {
+  ...proxyHandler,
+  get: (target, key) => {
+    if (key === proxyIdentifier) return true
+    return target[key]
+  }
+}
+
+function proxyFreeze (target, { addProxyIdentifier = false } = {}) {
   if (typeof target !== 'function' && typeof target !== 'object') {
     throw new Error('proxyFreeze only supports constructor functions or objects.')
   }
+  if (typeof addProxyIdentifier !== 'boolean') {
+    throw new TypeError('addProxyIdentifier needs to be a boolean.')
+  }
 
+  if (addProxyIdentifier) return new Proxy(target, identifiableProxyHandler)
   return new Proxy(target, proxyHandler)
 }
 
 module.exports = proxyFreeze
+module.exports.proxyIdentifier = proxyIdentifier

--- a/test.js
+++ b/test.js
@@ -39,3 +39,31 @@ test('should freeze objects from constructor', t => {
 
   t.is(p.name, 'jp', 'name didnt change')
 })
+
+test('should not identify proxy if addProxyIdentifier not set or false', t => {
+  t.plan(2)
+
+  let obj = {
+    name: 'jp'
+  }
+
+  let obj2 = proxyFreeze(obj)
+  t.is(obj2[proxyFreeze.proxyIdentifier], undefined, 'Proxy is not identified')
+
+  let obj3 = proxyFreeze(obj, { addProxyIdentifier: false })
+  t.is(obj3[proxyFreeze.proxyIdentifier], undefined, 'Proxy is not identified')
+  t.end()
+})
+
+test('should identify proxy if addProxyIdentifier is true', t => {
+  t.plan(1)
+
+  let obj = {
+    name: 'jp'
+  }
+
+  let obj2 = proxyFreeze(obj, { addProxyIdentifier: true })
+
+  t.is(obj2[proxyFreeze.proxyIdentifier], true, 'Proxy is identified')
+  t.end()
+})

--- a/test.js
+++ b/test.js
@@ -4,11 +4,11 @@ const proxyFreeze = require('./')
 test('should freze a regular object', t => {
   t.plan(2)
 
-  let obj = {
+  const obj = {
     name: 'jp'
   }
 
-  let obj2 = proxyFreeze(obj)
+  const obj2 = proxyFreeze(obj)
   obj2.name = 'bob'
 
   process.once('warning', ({ name }) => {
@@ -43,14 +43,14 @@ test('should freeze objects from constructor', t => {
 test('should not identify proxy if addProxyIdentifier not set or false', t => {
   t.plan(2)
 
-  let obj = {
+  const obj = {
     name: 'jp'
   }
 
-  let obj2 = proxyFreeze(obj)
+  const obj2 = proxyFreeze(obj)
   t.is(obj2[proxyFreeze.proxyIdentifier], undefined, 'Proxy is not identified')
 
-  let obj3 = proxyFreeze(obj, { addProxyIdentifier: false })
+  const obj3 = proxyFreeze(obj, { addProxyIdentifier: false })
   t.is(obj3[proxyFreeze.proxyIdentifier], undefined, 'Proxy is not identified')
   t.end()
 })
@@ -58,11 +58,11 @@ test('should not identify proxy if addProxyIdentifier not set or false', t => {
 test('should identify proxy if addProxyIdentifier is true', t => {
   t.plan(1)
 
-  let obj = {
+  const obj = {
     name: 'jp'
   }
 
-  let obj2 = proxyFreeze(obj, { addProxyIdentifier: true })
+  const obj2 = proxyFreeze(obj, { addProxyIdentifier: true })
 
   t.is(obj2[proxyFreeze.proxyIdentifier], true, 'Proxy is identified')
   t.end()
@@ -71,12 +71,12 @@ test('should identify proxy if addProxyIdentifier is true', t => {
 test('cannot use preventRefreeze without addProxyIdentifier', t => {
   t.plan(2)
 
-  let obj = {
+  const obj = {
     name: 'jp'
   }
 
   t.throws(() => proxyFreeze(obj, { preventRefreeze: true }), 'cannot use preventRefreeze without addProxyIdentifier.')
-  let obj2 = proxyFreeze(obj, { preventRefreeze: true, addProxyIdentifier: true })
+  const obj2 = proxyFreeze(obj, { preventRefreeze: true, addProxyIdentifier: true })
   t.is(obj2[proxyFreeze.proxyIdentifier], true, 'can use preventRefreeze with addProxyIdentifier.')
 
   t.end()
@@ -85,12 +85,12 @@ test('cannot use preventRefreeze without addProxyIdentifier', t => {
 test('shoud not re-freeze if preventRefreeze is true', t => {
   t.plan(1)
 
-  let obj = {
+  const obj = {
     name: 'jp'
   }
 
-  let obj2 = proxyFreeze(obj, { preventRefreeze: true, addProxyIdentifier: true })
-  let obj3 = proxyFreeze(obj2, { preventRefreeze: true, addProxyIdentifier: true })
+  const obj2 = proxyFreeze(obj, { preventRefreeze: true, addProxyIdentifier: true })
+  const obj3 = proxyFreeze(obj2, { preventRefreeze: true, addProxyIdentifier: true })
   t.is(obj2, obj3, 'we don\'t re-freeze.')
 
   t.end()
@@ -99,12 +99,12 @@ test('shoud not re-freeze if preventRefreeze is true', t => {
 test('shoud re-freeze if preventRefreeze is false', t => {
   t.plan(1)
 
-  let obj = {
+  const obj = {
     name: 'jp'
   }
 
-  let obj2 = proxyFreeze(obj)
-  let obj3 = proxyFreeze(obj2)
+  const obj2 = proxyFreeze(obj)
+  const obj3 = proxyFreeze(obj2)
   t.isNot(obj2, obj3, 'we re-freeze.')
 
   t.end()

--- a/test.js
+++ b/test.js
@@ -67,3 +67,45 @@ test('should identify proxy if addProxyIdentifier is true', t => {
   t.is(obj2[proxyFreeze.proxyIdentifier], true, 'Proxy is identified')
   t.end()
 })
+
+test('cannot use preventRefreeze without addProxyIdentifier', t => {
+  t.plan(2)
+
+  let obj = {
+    name: 'jp'
+  }
+
+  t.throws(() => proxyFreeze(obj, { preventRefreeze: true }), 'cannot use preventRefreeze without addProxyIdentifier.')
+  let obj2 = proxyFreeze(obj, { preventRefreeze: true, addProxyIdentifier: true })
+  t.is(obj2[proxyFreeze.proxyIdentifier], true, 'can use preventRefreeze with addProxyIdentifier.')
+
+  t.end()
+})
+
+test('shoud not re-freeze if preventRefreeze is true', t => {
+  t.plan(1)
+
+  let obj = {
+    name: 'jp'
+  }
+
+  let obj2 = proxyFreeze(obj, { preventRefreeze: true, addProxyIdentifier: true })
+  let obj3 = proxyFreeze(obj2, { preventRefreeze: true, addProxyIdentifier: true })
+  t.is(obj2, obj3, 'we don\'t re-freeze.')
+
+  t.end()
+})
+
+test('shoud re-freeze if preventRefreeze is false', t => {
+  t.plan(1)
+
+  let obj = {
+    name: 'jp'
+  }
+
+  let obj2 = proxyFreeze(obj)
+  let obj3 = proxyFreeze(obj2)
+  t.isNot(obj2, obj3, 'we re-freeze.')
+
+  t.end()
+})


### PR DESCRIPTION
Preventing re-freezing an already frozen object has perf benefits. But it also avoids bugs in some older javascript engines, e.g. `Object.keys` doesn't work on double-proxied objects on `jsc-android@236355.1.1`